### PR TITLE
fix: constant plot hovering + touch support

### DIFF
--- a/src/components/PlotComponent2.vue
+++ b/src/components/PlotComponent2.vue
@@ -1,5 +1,5 @@
 <template>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1000" style="width: 100%; aspect-ratio: 2/1;" ref="svg" @mouseover="inspect($event)" @mouseleave="pointer = undefined">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1000" style="width: 100%; aspect-ratio: 2/1;" ref="svg" @mousemove="inspect($event)" @mouseleave="pointer = undefined">
         <path d="M10 10 H1990 V990 H10 Z" stroke-width="10" stroke="#808080" fill="none"/>
         <path :d="`M${values.points[0].x} ${values.points[0].y} ${values.points.map(element => `L${element.x} ${element.y}`).join(' ')}`" stroke-width="10" stroke="yellow" fill="none"/>
         <path v-if="pointer" :d="`M${pointer.x} 10 V999`" stroke-width="10" stroke="white" fill="none"/>
@@ -29,7 +29,6 @@ function inspect(event: MouseEvent) {
     const rect = svg.value?.getBoundingClientRect()
     if (!rect || !rect.left) return
     const x = Math.round((event.clientX - rect.left) * (values.value.width / rect.width) / values.value.stepX)
-    console.log(x)
     pointer.value = { x: (x * values.value.stepX).toFixed(0), y: (values.value.height - (props.y[x] - values.value.yMin) * values.value.stepY).toFixed(0), value: { x: props.x[x], y: props.y[x] }}
 }
 

--- a/src/components/PlotComponent2.vue
+++ b/src/components/PlotComponent2.vue
@@ -1,5 +1,5 @@
 <template>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1000" style="width: 100%; aspect-ratio: 2/1;" ref="svg" @mousemove="inspect($event)" @mouseleave="pointer = undefined">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1000" style="width: 100%; aspect-ratio: 2/1;" ref="svg" @mousemove="inspectMouse($event)"  @touchstart="" @touchmove="inspectTouch($event)" @mouseleave="pointer = undefined" @touchend="pointer = undefined">
         <path d="M10 10 H1990 V990 H10 Z" stroke-width="10" stroke="#808080" fill="none"/>
         <path :d="`M${values.points[0].x} ${values.points[0].y} ${values.points.map(element => `L${element.x} ${element.y}`).join(' ')}`" stroke-width="10" stroke="yellow" fill="none"/>
         <path v-if="pointer" :d="`M${pointer.x} 10 V999`" stroke-width="10" stroke="white" fill="none"/>
@@ -13,6 +13,7 @@ const props = defineProps<{ x: number[] | string[], y: number[] }>()
 const svg = useTemplateRef('svg')
 
 const pointer = ref<{ x: string, y: string, value: { x: number | string, y: number } } | undefined>(undefined)
+const touchObjects = []
 
 const values = computed(() => {
     const [height, width] = [1000, 2000]
@@ -25,10 +26,19 @@ const values = computed(() => {
     return { height, width, xMin, xMax, yMin, yMax, stepX, stepY, points }
 })
 
-function inspect(event: MouseEvent) {
+function inspectMouse(event: MouseEvent) {
     const rect = svg.value?.getBoundingClientRect()
     if (!rect || !rect.left) return
     const x = Math.round((event.clientX - rect.left) * (values.value.width / rect.width) / values.value.stepX)
+    pointer.value = { x: (x * values.value.stepX).toFixed(0), y: (values.value.height - (props.y[x] - values.value.yMin) * values.value.stepY).toFixed(0), value: { x: props.x[x], y: props.y[x] }}
+}
+
+function inspectTouch(event: TouchEvent) {
+    const rect = svg.value?.getBoundingClientRect()
+    if (!rect || !rect.left) return    
+    const touchPosX = event.touches?.[0]?.clientX;
+    if (!touchPosX) return
+    const x = Math.round((touchPosX - rect.left) * (values.value.width / rect.width) / values.value.stepX)
     pointer.value = { x: (x * values.value.stepX).toFixed(0), y: (values.value.height - (props.y[x] - values.value.yMin) * values.value.stepY).toFixed(0), value: { x: props.x[x], y: props.y[x] }}
 }
 

--- a/src/components/PlotComponent2.vue
+++ b/src/components/PlotComponent2.vue
@@ -1,7 +1,7 @@
 <template>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1000" style="width: 100%; aspect-ratio: 2/1;" ref="svg" @mousemove="inspectMouse($event)"  @touchstart="" @touchmove="inspectTouch($event)" @mouseleave="pointer = undefined" @touchend="pointer = undefined">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2000 1000" style="width: 100%; aspect-ratio: 2/1;" ref="svg" @mousemove="inspectMouse($event)" @mouseleave="pointer = undefined" @touchmove="inspectTouch($event)" @touchend="pointer = undefined" @touchcancel="pointer = undefined">
         <path d="M10 10 H1990 V990 H10 Z" stroke-width="10" stroke="#808080" fill="none"/>
-        <path :d="`M${values.points[0].x} ${values.points[0].y} ${values.points.map(element => `L${element.x} ${element.y}`).join(' ')}`" stroke-width="10" stroke="yellow" fill="none"/>
+        <path :d="`M${values.points[0].x} ${values.points[0].y} ${values.points.map(element => `L${element.x} ${element.y}`).join(' ')}`" stroke-width="10" stroke="yellow" fill="none"/> 
         <path v-if="pointer" :d="`M${pointer.x} 10 V999`" stroke-width="10" stroke="white" fill="none"/>
         <circle v-if="pointer" r="20" :cx="pointer.x" :cy="pointer.y" stroke-width="2" stroke="white" fill="white"/>
     </svg>
@@ -13,7 +13,6 @@ const props = defineProps<{ x: number[] | string[], y: number[] }>()
 const svg = useTemplateRef('svg')
 
 const pointer = ref<{ x: string, y: string, value: { x: number | string, y: number } } | undefined>(undefined)
-const touchObjects = []
 
 const values = computed(() => {
     const [height, width] = [1000, 2000]
@@ -38,6 +37,8 @@ function inspectTouch(event: TouchEvent) {
     if (!rect || !rect.left) return    
     const touchPosX = event.touches?.[0]?.clientX;
     if (!touchPosX) return
+
+    event.preventDefault();
     const x = Math.round((touchPosX - rect.left) * (values.value.width / rect.width) / values.value.stepX)
     pointer.value = { x: (x * values.value.stepX).toFixed(0), y: (values.value.height - (props.y[x] - values.value.yMin) * values.value.stepY).toFixed(0), value: { x: props.x[x], y: props.y[x] }}
 }


### PR DESCRIPTION
Resolved an issue where the weather-plot-pointer would only partially respond when the cursor moved within the plot area. The pointer now correctly tracks hovering across the entire plot.
The plot can now be inspect by using a touch device.